### PR TITLE
Video Receiver Endpoint

### DIFF
--- a/src/AppSettings.py
+++ b/src/AppSettings.py
@@ -6,6 +6,7 @@ class AppSettings:
     ExperimentsEndpoint: str
     ResultsEndpoint: str
     ListenerTargetFolder: str
+    VideoRevieverTargetFolder: str
 
 def GetAppSettings():
     import os 

--- a/src/AppSettings.py
+++ b/src/AppSettings.py
@@ -7,6 +7,7 @@ class AppSettings:
     ResultsEndpoint: str
     ListenerTargetFolder: str
     VideoRevieverTargetFolder: str
+    EncodedVideoFileNamePattern: str
 
 def GetAppSettings():
     import os 

--- a/src/VideoRecieverApi.py
+++ b/src/VideoRecieverApi.py
@@ -1,0 +1,31 @@
+from flask import Flask, request
+from AppSettings import AppSettings, GetAppSettings
+import os
+
+print("Starting API")
+app = Flask(__name__)
+
+@app.route('/')
+def test():
+    return 'Hello World!'
+
+# Uploads file to the configured directory
+# Takes form data with 'file' (file) 'experimentId' (string) and 'sequenceNumber' (int)
+# This enforces naming convention
+@app.route('/encoded/upload', methods = ['POST'])
+def getExperimentById():
+    if 'file' not in request.files:
+        return "File not found - make sure the form data has a 'file' field with the attached video", 400
+    if 'experimentId' not in request.form or 'sequenceNumber' not in request.form:
+        return "Experiment ID (string) and sequence number (integer) must be provided in the form data", 400
+    
+    #TODO: Validate mp4?
+    file = request.files['file']
+    filename = request.form['experimentId'] + "_" + request.form['sequenceNumber'] + "_encoded.mp4"
+
+    filePath = os.path.join(GetAppSettings().ListenerTargetFolder, filename)
+    file.save(filePath)
+
+    return "Video received and saved successfully", 200
+
+app.run(port=5000)

--- a/src/VideoRecieverApi.py
+++ b/src/VideoRecieverApi.py
@@ -19,7 +19,7 @@ def getExperimentById():
     if 'experimentId' not in request.form or 'sequenceNumber' not in request.form:
         return "Experiment ID (string) and sequence number (integer) must be provided in the form data", 400
     
-    #TODO: Validate mp4?
+    #TODO: Validate mp4?, authenticate?
     file = request.files['file']
     filename = request.form['experimentId'] + "_" + request.form['sequenceNumber'] + "_encoded.mp4"
 

--- a/src/VideoRecieverApi.py
+++ b/src/VideoRecieverApi.py
@@ -1,5 +1,6 @@
 from flask import Flask, request
 from AppSettings import AppSettings, GetAppSettings
+from processing.FileNameValidator import FileNameValidator
 import os
 
 print("Starting API")
@@ -22,6 +23,9 @@ def getExperimentById():
     #TODO: Validate mp4?, authenticate?
     file = request.files['file']
     filename = request.form['experimentId'] + "_" + request.form['sequenceNumber'] + "_encoded.mp4"
+
+    if not FileNameValidator().ValidateEncodedVideoName(filename):
+        return "Generated name does not follow the expected pattern", 400
 
     filePath = os.path.join(GetAppSettings().ListenerTargetFolder, filename)
     file.save(filePath)

--- a/src/_tests/test_appsettings.py
+++ b/src/_tests/test_appsettings.py
@@ -1,0 +1,8 @@
+from AppSettings import GetAppSettings
+
+def test_can_get_appsettings():
+    appSettings = GetAppSettings()
+    
+    assert appSettings is not None
+    assert len(appSettings.ExperimentsEndpoint) > 0
+    assert len(appSettings.ResultsEndpoint) > 0

--- a/src/_tests/test_naming.py
+++ b/src/_tests/test_naming.py
@@ -1,0 +1,16 @@
+from processing.FileNameValidator import FileNameValidator
+
+def test_simple_name_works():
+    assert FileNameValidator().ValidateEncodedVideoName("testid_1_encoded.mp4") == True
+
+def test_complex_name_works():
+    assert FileNameValidator().ValidateEncodedVideoName("6d8518a5-7057-4e9d-b7d7-76465c29158e_20_encoded.mp4") == True
+
+def test_name_without_suffix_fails():
+    assert FileNameValidator().ValidateEncodedVideoName("testid_1") == False
+
+def test_invalid_sequence_fails():
+    assert FileNameValidator().ValidateEncodedVideoName("testid_one_encoded.mp4") == False
+
+def test_prefix_fails():
+    assert FileNameValidator().ValidateEncodedVideoName("test_testid_1_encoded.mp3") == False

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -3,5 +3,5 @@
     "ResultsEndpoint": "http://localhost:5002",
     "ListenerTargetFolder": "./in",
     "VideoRevieverTargetFolder": "./in",
-    "EncodedVideoFileNamePattern": "[A-Za-z0-9-]+_[0-9+]_encoded.mp4"
+    "EncodedVideoFileNamePattern": "[A-Za-z0-9-]+_[0-9]+_encoded.mp4"
 }

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -1,5 +1,6 @@
 {
     "ExperimentsEndpoint": "http://localhost:5001",
     "ResultsEndpoint": "http://localhost:5002",
-    "ListenerTargetFolder": "./in"
+    "ListenerTargetFolder": "./in",
+    "VideoRevieverTargetFolder": "./in"
 }

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -2,5 +2,6 @@
     "ExperimentsEndpoint": "http://localhost:5001",
     "ResultsEndpoint": "http://localhost:5002",
     "ListenerTargetFolder": "./in",
-    "VideoRevieverTargetFolder": "./in"
+    "VideoRevieverTargetFolder": "./in",
+    "EncodedVideoFileNamePattern": "[A-Za-z0-9-]+_[0-9+]_encoded.mp4"
 }

--- a/src/processing/DirectoryListener.py
+++ b/src/processing/DirectoryListener.py
@@ -1,6 +1,7 @@
 from AppSettings import AppSettings, GetAppSettings
 from exceptions.KnownProcessingException import KnownProcessingException
 from processing.Counter import Counter
+from processing.FileNameValidator import FileNameValidator
 import os
 import time
 from typing import Callable
@@ -49,8 +50,7 @@ class DirectoryListener:
                 counter.reset()
                 print("File detected: " + files[0])
 
-                pattern = re.compile("[A-Za-z0-9-]+_[0-9+]_encoded.mp4") #File-Id_1_encoded.mp4 would be valid, for example
-                if not pattern.fullmatch(files[0]):
+                if not FileNameValidator().ValidateEncodedVideoName(files[0]):
                     print("File name did not follow expected pattern, moving to poison queue")
                     self.moveToPoison(files[0])
                     continue

--- a/src/processing/FileNameValidator.py
+++ b/src/processing/FileNameValidator.py
@@ -1,0 +1,9 @@
+from AppSettings import GetAppSettings
+import re
+
+class FileNameValidator:
+    def ValidateEncodedVideoName(self, fileName: str) -> bool:
+        pattern = re.compile(GetAppSettings().EncodedVideoFileNamePattern) #File-Id_1_encoded.mp4 would be valid, for example
+        if pattern.fullmatch(fileName):
+            return True
+        return False


### PR DESCRIPTION
Added a simple flask API that can receive a video for the sake of hardware independence.

Also refactored to make naming validation reusable and configurable.

Sample endpoint:
![image](https://github.com/user-attachments/assets/a2e6aded-7722-4dd6-abe9-ac6448fc01bd)
